### PR TITLE
Set minimal mass on skeleton bone links to prevent 1kg default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+Changelog
+=========
+
+0.2.0 (2026-04-13)
+-------------------
+
+- Set minimal mass (0.001 kg) on skeleton bone links to prevent Gazebo default 1 kg
+
+0.1.0
+-----
+
+- Initial release

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>gazebo_skeleton_visual_model_plugin</name>
-  <version>0.1.0</version>
+  <version>0.2.0</version>
   <description>Model plugin package for gazebo to visualize skeleton</description>
 
   <maintainer email="dev@groove-x.com">GROOVE X, Inc</maintainer>

--- a/src/skeleton_model_plugin.cpp
+++ b/src/skeleton_model_plugin.cpp
@@ -108,6 +108,7 @@ bool SkeletonModelVisual::LoadSkin(sdf::ElementPtr _skinSdf, sdf::ElementPtr _ta
   linkSdf->GetAttribute("name")->Set(modelName + "_pose");
   linkSdf->GetElement("gravity")->Set(false);
   linkSdf->GetElement("self_collide")->Set(false);
+  this->AddSphereInertia(linkSdf, ignition::math::Pose3d::Zero, 1e-3, 0.01);
 
   std::string modelLinkName = modelName + "::" + modelName + "_pose";
   this->visualName = modelLinkName + "::" + modelName + "_visual";
@@ -135,9 +136,8 @@ bool SkeletonModelVisual::LoadSkin(sdf::ElementPtr _skinSdf, sdf::ElementPtr _ta
 
     linkSdf->GetElement("pose")->Set(pose);
 
-    // FIXME hardcoded inertia of a sphere with mass 1.0 and radius 0.01
-    // Do we even need inertial info in an actor?
-    // this->AddSphereInertia(linkSdf, ignition::math::Pose3d::Zero, 1.0, 0.01);
+    // Set minimal inertia to prevent Gazebo's default 1 kg mass per link
+    this->AddSphereInertia(linkSdf, ignition::math::Pose3d::Zero, 1e-3, 0.01);
 
     // FIXME hardcoded visual to red sphere with radius 0.02
     if (bone->IsRootNode())


### PR DESCRIPTION
## Summary

Gazebo assigns a default mass of 1 kg to links created without explicit inertial properties. The skeleton plugin creates N+1 links (one pose link + N skeleton nodes) without inertial, adding N+1 kg to the total model mass.

This fix sets mass=0.001 kg with sphere inertia on all dynamically created bone links, keeping the total model mass accurate to the URDF-defined physics mass.

## Changes

- Add `AddSphereInertia` call for the pose link (root visual link)
- Uncomment and fix `AddSphereInertia` call for skeleton node links, using mass=1e-3 instead of the original 1.0

## Impact

For a model with 33 skeleton nodes: total bone mass reduced from 34 kg to 0.034 kg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)